### PR TITLE
Fix:Tflite detext error: cv2.error: OpenCV(4.5.2) :-1: error: (-5:Bad…… argument) in function 'rectangle'

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -245,7 +245,7 @@ def draw_bbox(image, bboxes, info = False, counted_classes = None, show_label=Tr
 
             bbox_color = colors[class_ind]
             bbox_thick = int(0.6 * (image_h + image_w) / 600)
-            c1, c2 = (coor[0], coor[1]), (coor[2], coor[3])
+            c1, c2 = (int(coor[0]), int(coor[1])), (int(coor[2]), int(coor[3]))
             cv2.rectangle(image, c1, c2, bbox_color, bbox_thick)
 
             if info:
@@ -255,9 +255,9 @@ def draw_bbox(image, bboxes, info = False, counted_classes = None, show_label=Tr
                 bbox_mess = '%s: %.2f' % (class_name, score)
                 t_size = cv2.getTextSize(bbox_mess, 0, fontScale, thickness=bbox_thick // 2)[0]
                 c3 = (c1[0] + t_size[0], c1[1] - t_size[1] - 3)
-                cv2.rectangle(image, c1, (np.float32(c3[0]), np.float32(c3[1])), bbox_color, -1) #filled
+                cv2.rectangle(image, c1, (int(c3[0]), int(c3[1])), bbox_color, -1) #filled
 
-                cv2.putText(image, bbox_mess, (c1[0], np.float32(c1[1] - 2)), cv2.FONT_HERSHEY_SIMPLEX,
+                cv2.putText(image, bbox_mess, (c1[0], int(c1[1] - 2)), cv2.FONT_HERSHEY_SIMPLEX,
                         fontScale, (0, 0, 0), bbox_thick // 2, lineType=cv2.LINE_AA)
 
             if counted_classes != None:


### PR DESCRIPTION
cv2.rectangle takes parameters of the dimension as integers instead of float.
So typecasting the calculated dimensions to integers
